### PR TITLE
Fix data race when rendering an LCD display

### DIFF
--- a/examples/board_hd44780/Makefile
+++ b/examples/board_hd44780/Makefile
@@ -33,9 +33,10 @@ LDFLAGS += -lpthread
 
 include ../Makefile.opengl
 
-all: obj atmega48_charlcd.axf ${target} 
+all: obj atmega48_charlcd.axf atmega48_fps_test.axf ${target} 
 
 atmega48_charlcd.axf: atmega48_charlcd.c
+atmega48_fps_test.axf: atmega48_fps_test.c
 
 include ${simavr}/Makefile.common
 

--- a/examples/board_hd44780/atmega48_fps_test.c
+++ b/examples/board_hd44780/atmega48_fps_test.c
@@ -1,0 +1,47 @@
+#undef F_CPU
+#define F_CPU 16000000
+
+#include <avr/io.h>
+
+#include "avr_mcu_section.h"
+AVR_MCU(F_CPU, "atmega48");
+
+#include "avr_hd44780.c"
+
+int main()
+{
+	hd44780_init();
+	/*
+	 * Clear the display.
+	 */
+	hd44780_outcmd(HD44780_CLR);
+	hd44780_wait_ready(1); // long wait
+
+	/*
+	 * Entry mode: auto-increment address counter, no display shift in
+	 * effect.
+	 */
+	hd44780_outcmd(HD44780_ENTMODE(1, 0));
+	hd44780_wait_ready(0);
+
+	/*
+	 * Enable display, activate non-blinking cursor.
+	 */
+	hd44780_outcmd(HD44780_DISPCTL(1, 1, 0));
+	hd44780_wait_ready(0);
+
+	uint16_t count = 0;
+	while (1)
+	{
+		uint16_t temp = count;
+		for (uint8_t i = 5; i > 0; i--)
+		{
+			hd44780_outcmd(HD44780_DDADDR(i - 1));
+			hd44780_wait_ready(0);
+			hd44780_outdata(temp % 10 + 48);
+			temp /= 10;
+			hd44780_wait_ready(0);
+		}
+		count++;
+	}
+}

--- a/examples/board_hd44780/charlcd.c
+++ b/examples/board_hd44780/charlcd.c
@@ -146,11 +146,15 @@ main(
 		char *argv[])
 {
 	elf_firmware_t f = {{0}};
-	const char * fname = "atmega48_charlcd.axf";
+	const char *fname = argc > 1 ? argv[1] : "atmega48_charlcd.axf";
 //	char path[256];
 //	sprintf(path, "%s/%s", dirname(argv[0]), fname);
 //	printf("Firmware pathname is %s\n", path);
-	elf_read_firmware(fname, &f);
+	if (elf_read_firmware(fname, &f) == -1)
+	{
+		fprintf(stderr, "Unable to load firmware from file %s\n", fname);
+		exit(EXIT_FAILURE);
+	};
 
 	printf("firmware %s f=%d mmcu=%s\n", fname, (int) f.frequency, f.mmcu);
 
@@ -167,6 +171,8 @@ main(
 			AVR_IOCTL_IOPORT_GETIRQ('D'), 2));
 
 	hd44780_init(avr, &hd44780, 20, 4);
+
+	hd44780_setup_mutex_for_gl(&hd44780);
 
 	/* Connect Data Lines to Port B, 0-3 */
 	/* These are bidirectional too */

--- a/examples/board_hd44780/charlcd.c
+++ b/examples/board_hd44780/charlcd.c
@@ -172,6 +172,8 @@ main(
 
 	hd44780_init(avr, &hd44780, 20, 4);
 
+	hd44780_setup_mutex_for_gl(&hd44780);
+
 	/* Connect Data Lines to Port B, 0-3 */
 	/* These are bidirectional too */
 	for (int i = 0; i < 4; i++) {

--- a/examples/board_hd44780/charlcd.c
+++ b/examples/board_hd44780/charlcd.c
@@ -146,11 +146,15 @@ main(
 		char *argv[])
 {
 	elf_firmware_t f = {{0}};
-	const char * fname = "atmega48_charlcd.axf";
+	const char *fname = argc > 1 ? argv[1] : "atmega48_charlcd.axf";
 //	char path[256];
 //	sprintf(path, "%s/%s", dirname(argv[0]), fname);
 //	printf("Firmware pathname is %s\n", path);
-	elf_read_firmware(fname, &f);
+	if (elf_read_firmware(fname, &f) == -1)
+	{
+		fprintf(stderr, "Unable to load firmware from file %s\n", fname);
+		exit(EXIT_FAILURE);
+	};
 
 	printf("firmware %s f=%d mmcu=%s\n", fname, (int) f.frequency, f.mmcu);
 

--- a/examples/board_olimex_avr_mt128/mt128.c
+++ b/examples/board_olimex_avr_mt128/mt128.c
@@ -319,6 +319,7 @@ static void setup_ui()
 	glEnable(GL_BLEND);
 
 	hd44780_gl_init();
+	hd44780_setup_mutex_for_gl(&hd44780);
 }
 
 

--- a/examples/parts/hd44780.c
+++ b/examples/parts/hd44780.c
@@ -76,7 +76,7 @@ _hd44780_busy_timer(
 {
 	hd44780_t *b = (hd44780_t *) param;
 //	printf("%s called\n", __FUNCTION__);
-	hd44780_set_flag(b, HD44780_FLAG_BUSY, 0);
+	hd44780_set_private_flag(b, HD44780_PRIV_FLAG_BUSY, 0);
 	avr_raise_irq(b->irq + IRQ_HD44780_BUSY, 0);
 	return 0;
 }
@@ -193,7 +193,7 @@ hd44780_write_command(
 			hd44780_set_flag(b, HD44780_FLAG_F, b->datapins & 4);
 			if (!four && !hd44780_get_flag(b, HD44780_FLAG_D_L)) {
 				printf("%s activating 4 bits mode\n", __FUNCTION__);
-				hd44780_set_flag(b, HD44780_FLAG_LOWNIBBLE, 0);
+				hd44780_set_private_flag(b, HD44780_PRIV_FLAG_LOWNIBBLE, 0);
 			}
 		}	break;
 		// Cursor display shift
@@ -235,7 +235,7 @@ hd44780_process_write(
 {
 	uint32_t delay = 0; // uS
 	int four = !hd44780_get_flag(b, HD44780_FLAG_D_L);
-	int comp = four && hd44780_get_flag(b, HD44780_FLAG_LOWNIBBLE);
+	int comp = four && hd44780_get_private_flag(b, HD44780_PRIV_FLAG_LOWNIBBLE);
 	int write = 0;
 
 	if (four) { // 4 bits !
@@ -244,7 +244,7 @@ hd44780_process_write(
 		else
 			b->datapins = (b->datapins & 0xf) | ((b->pinstate >>  (IRQ_HD44780_D4-4)) & 0xf0);
 		write = comp;
-		b->flags ^= (1 << HD44780_FLAG_LOWNIBBLE);
+		b->private_flags ^= (1 << HD44780_PRIV_FLAG_LOWNIBBLE);
 	} else {	// 8 bits
 		b->datapins = (b->pinstate >>  IRQ_HD44780_D0) & 0xff;
 		write++;
@@ -253,13 +253,15 @@ hd44780_process_write(
 
 	// write has 8 bits to process
 	if (write) {
-		if (hd44780_get_flag(b, HD44780_FLAG_BUSY)) {
+		if (hd44780_get_private_flag(b, HD44780_PRIV_FLAG_BUSY)) {
 			printf("%s command %02x write when still BUSY\n", __FUNCTION__, b->datapins);
 		}
+		hd44780_lock_state(b);
 		if (b->pinstate & (1 << IRQ_HD44780_RS))	// write data
 			delay = hd44780_write_data(b);
 		else										// write command
 			delay = hd44780_write_command(b);
+		hd44780_unlock_state(b);
 	}
 	return delay;
 }
@@ -270,14 +272,14 @@ hd44780_process_read(
 {
 	uint32_t delay = 0; // uS
 	int four = !hd44780_get_flag(b, HD44780_FLAG_D_L);
-	int comp = four && hd44780_get_flag(b, HD44780_FLAG_LOWNIBBLE);
+	int comp = four && hd44780_get_private_flag(b, HD44780_PRIV_FLAG_LOWNIBBLE);
 	int done = 0;	// has something on the datapin we want
 
 	if (comp) {
 		// ready the 4 final bits on the 'actual' lcd pins
 		b->readpins <<= 4;
 		done++;
-		b->flags ^= (1 << HD44780_FLAG_LOWNIBBLE);
+		b->private_flags ^= (1 << HD44780_PRIV_FLAG_LOWNIBBLE);
 	}
 
 	if (!done) { // new read
@@ -285,19 +287,21 @@ hd44780_process_read(
 		if (b->pinstate & (1 << IRQ_HD44780_RS)) {	// read data
 			delay = 37;
 			b->readpins = b->vram[b->cursor];
+			hd44780_lock_state(b);
 			hd44780_kick_cursor(b);
+			hd44780_unlock_state(b);
 		} else {	// read 'command' ie status register
 			delay = 0;	// no raising busy when reading busy !
 
 			// low bits are the current cursor
 			b->readpins = b->cursor < 0x80 ? b->cursor : b->cursor-0x80;
-			int busy = hd44780_get_flag(b, HD44780_FLAG_BUSY);
+			int busy = hd44780_get_private_flag(b, HD44780_PRIV_FLAG_BUSY);
 			b->readpins |= busy ? 0x80 : 0;
 
 		//	if (busy) printf("Good boy, guy's reading status byte\n");
 			// now that we're read the busy flag, clear it and clear
 			// the timer too
-			hd44780_set_flag(b, HD44780_FLAG_BUSY, 0);
+			hd44780_set_private_flag(b, HD44780_PRIV_FLAG_BUSY, 0);
 			avr_raise_irq(b->irq + IRQ_HD44780_BUSY, 0);
 			avr_cycle_timer_cancel(b->avr, _hd44780_busy_timer, b);
 		}
@@ -305,7 +309,7 @@ hd44780_process_read(
 
 		done++;
 		if (four)
-			b->flags |= (1 << HD44780_FLAG_LOWNIBBLE); // for next read
+			b->private_flags |= (1 << HD44780_PRIV_FLAG_LOWNIBBLE); // for next read
 	}
 
 	// now send the prepared output pins to send as IRQs
@@ -324,7 +328,7 @@ _hd44780_process_e_pinchange(
 {
 	hd44780_t *b = (hd44780_t *) param;
 
-	hd44780_set_flag(b, HD44780_FLAG_REENTRANT, 1);
+	hd44780_set_private_flag(b, HD44780_PRIV_FLAG_REENTRANT, 1);
 
 #if 0
 	uint16_t touch = b->oldstate ^ b->pinstate;
@@ -342,13 +346,13 @@ _hd44780_process_e_pinchange(
 		delay = hd44780_process_write(b);
 
 	if (delay) {
-		hd44780_set_flag(b, HD44780_FLAG_BUSY, 1);
+		hd44780_set_private_flag(b, HD44780_PRIV_FLAG_BUSY, 1);
 		avr_raise_irq(b->irq + IRQ_HD44780_BUSY, 1);
 		avr_cycle_timer_register_usec(b->avr, delay,
 			_hd44780_busy_timer, b);
 	}
 //	b->oldstate = b->pinstate;
-	hd44780_set_flag(b, HD44780_FLAG_REENTRANT, 0);
+	hd44780_set_private_flag(b, HD44780_PRIV_FLAG_REENTRANT, 0);
 	return 0;
 }
 
@@ -377,7 +381,7 @@ hd44780_pin_changed_hook(
 			return; // job already done!
 		case IRQ_HD44780_D0 ... IRQ_HD44780_D7:
 			// don't update these pins in read mode
-			if (hd44780_get_flag(b, HD44780_FLAG_REENTRANT))
+			if (hd44780_get_private_flag(b, HD44780_PRIV_FLAG_REENTRANT))
 				return;
 			break;
 	}

--- a/examples/parts/hd44780_glut.h
+++ b/examples/parts/hd44780_glut.h
@@ -24,6 +24,14 @@
 
 #include "hd44780.h"
 
+// This sets the change callbacks of the hd44780 to
+// lock and unlock the mutex of the internal display.
+void
+hd44780_setup_mutex_for_gl(hd44780_t *b);
+
+// Draws the contents of the LCD display.
+// You must call hd44780_gl_init() and
+// hd44780_setup_mutex_for_gl() first.
 void
 hd44780_gl_draw(
 		hd44780_t *b,


### PR DESCRIPTION
###Summary

The example code for the LCD display uses two threads: one for simulating the AVR chip, and one for OpenGL. The state of the LCD display is stored as some flags in a uint16_t variable. When the OpenGL thread modifies a flag, it may accidentally undo a simultaneous write operation in the AVR thread, causing malfunction of the display.

The full description is available at [https://github.com/buserror/simavr/pull/507](https://github.com/buserror/simavr/pull/507).